### PR TITLE
fix: Lambda Security Group and Subnet Tag

### DIFF
--- a/deploy/app/data.tf
+++ b/deploy/app/data.tf
@@ -13,6 +13,6 @@ data "aws_subnets" "private" {
   }
 
   tags = {
-    Tier = "private"
+    tier = "private"
   }
 }

--- a/deploy/app/main.tf
+++ b/deploy/app/main.tf
@@ -19,7 +19,7 @@ module "lambda_sg" {
 
   ingress_cidr_blocks = ["${data.aws_vpc.vpc.cidr_block}"]
   ingress_rules       = ["all-all"]
-  egress_rules        = ["nomad-http-tcp"]
+  egress_rules        = ["http-80-tcp"]
 }
 
 module "lambda_function" {


### PR DESCRIPTION
This PR fixes the following:
1. Sets the default port being used by the Lambda function to call the Nomad API to port 80 instead of 4646.
2. Uses the proper key when looking up the subnets under a given VPC.

Note: the changes in this PR were tested and confirmed working using the following:
```sh
API_ID="<id>"
API_KEY=""
AWS_REGION="<region>"
FILE="job.hcl"

curl -v -X POST "https://${API_ID}.execute-api.${AWS_REGION}.amazonaws.com/v1/deploy" \
  -H "Authorization: ${API_KEY}" \
  -H "Content-Type: application/hcl" \
  --data-binary @"${FILE}"
```